### PR TITLE
McStasMcXtrace -> mccode-dev

### DIFF
--- a/.github/workflows/register.yml
+++ b/.github/workflows/register.yml
@@ -23,10 +23,10 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      - name: Clone McStasMcXtrace/McCode
+      - name: Clone mccode-dev/McCode
         uses: actions/checkout@v4
         with:
-          repository: McStasMcXtrace/McCode
+          repository: mccode-dev/McCode
           path: mccode
           fetch-depth: 0
           fetch-tags: true
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Pooch registry files for McStas/McXtrace
-Trialing solution 2 for https://github.com/McStasMcXtrace/McCode/issues/1529
+Trialing solution 2 for https://github.com/mccode-dev/McCode/issues/1529
 
 
 ## Tips for local development
@@ -11,7 +11,7 @@ git clone https://github.com/g5t/mccode-pooch.git mccode_pooch
 Clone the McCode repository inside of this one, e.g.,
 ```bash
 cd mccode_pooch
-git clone https://github.com/McStasMcXtrace/McCode.git mccode
+git clone https://github.com/mccode-dev/McCode.git mccode
 ```
 
 Setup a local development environment


### PR DESCRIPTION
Avoid needing to handle HTTP 301 responses since the McStasMcXtrace GitHub organization moved to mccode-dev.
This also prevents future problems if a new user or organization takes the name McStasMcXtrace.